### PR TITLE
Add transformers `Map<K,V>.havingKeys()` and `Map<K,V>.havingValues()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - the receiver types for `isTrue()`, `isFalse()`, and `isInstanceOf()` have been widened to operate on nullable values.
 - signature of `isIn` and `isNotIn` has been changed to ensure at least two items are supplied.
 - added assertions `isIn(Iterable<T>)` and `isNotIn(Iterable<T>)`
+- added transformers `Map<K,V>.havingKeys()` and `Map<K,V>.havingValues()`
 
 ## [0.28.1] 2024-04-17
 

--- a/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
@@ -173,3 +173,33 @@ fun <K, V> Assert<Map<K, V>>.key(key: K): Assert<V> = transform(appendName(show(
         expected("to have key:${show(key)}")
     }
 }
+
+/**
+ * Returns an assert that has a collection of the keys in the map.
+ * ```
+ * assertThat(mapOf("key" to "value")).havingKeys().containsOnly("key")
+ * ```
+ * @see havingValues
+ */
+fun <K, V> Assert<Map<K, V>>.havingKeys(): Assert<Set<K>> = transform {
+    if (it.isEmpty()) {
+        expected("map to not be empty")
+    } else {
+        it.keys
+    }
+}
+
+/**
+ * Returns an assert that has a collection of the values in the map.
+ * ```
+ * assertThat(mapOf("key" to "value")).havingValues().containsOnly("value")
+ * ```
+ * @see havingKeys
+ */
+fun <K, V> Assert<Map<K, V>>.havingValues(): Assert<Collection<V>> = transform {
+    if (it.isEmpty()) {
+        expected("map to not be empty")
+    } else {
+        it.values
+    }
+}

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/MapTest.kt
@@ -287,4 +287,34 @@ class MapTest {
         assertEquals("expected [subject] to have key:<\"wrong\">", error.message)
     }
     //endregion
+
+    //region havingKeys
+    @Test
+    fun havingKeys_empty_list_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(emptyMap<String, String>()).havingKeys()
+        }
+        assertEquals("expected map to not be empty", error.message)
+    }
+
+    @Test
+    fun havingKeys_assertion_passes() {
+        assertThat(mapOf("key" to "value")).havingKeys().containsOnly("key")
+    }
+    //endregion
+
+    //region havingValues
+    @Test
+    fun havingValues_empty_list_fails() {
+        val error = assertFailsWith<AssertionError> {
+            assertThat(emptyMap<String, String>()).havingKeys()
+        }
+        assertEquals("expected map to not be empty", error.message)
+    }
+
+    @Test
+    fun havingValues_assertion_passes() {
+        assertThat(mapOf("key" to "value")).havingValues().containsOnly("value")
+    }
+    //endregion
 }


### PR DESCRIPTION
This adds some transformers allowing you to utilize `Collection` asserts on parts of a map.

Example for keys:
```kotlin
assertThat(mapOf("key" to "value")).havingKeys().containsOnly("key")
```
Example for values: 
```kotlin
assertThat(mapOf("key" to "value")).havingValues().containsOnly("value")
```

Given that there is already a `Map<K,V>.isNotEmpty()` I thought it made sense to have these transformers throw an error if their corresponding parts have no values.

fixes #527 